### PR TITLE
Define the initial NixOS configuration of webforge in a flake

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,30 @@
+{
+  "nodes": {
+    "nixpkgs-24_11": {
+      "locked": {
+        "lastModified": 1738112643,
+        "narHash": "sha256-Y09D3YAi8iIVm3V6S0Y4jjr5DP8a9heXq1056D8IIP4=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "95568291fa92a2807b3669cc576ab0592e2293b9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-24.11-small",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs-24_11"
+        ],
+        "nixpkgs-24_11": "nixpkgs-24_11"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,23 @@
+{
+  inputs = {
+    # The nixpkgs channels we want to consume
+    nixpkgs-24_11.url = "github:NixOS/nixpkgs/nixos-24.11-small";
+
+    # Some links to the above channels for consistent naming in outputs
+    nixpkgs.follows = "nixpkgs-24_11";
+  };
+  outputs = { self, nixpkgs, ... }@attrs: {
+    # Generate an attrset of nixosConfigurations based on their system name
+    nixosConfigurations = nixpkgs.lib.attrsets.genAttrs [
+      "webforge"
+    ] (sysname: nixpkgs.lib.nixosSystem {
+        system = "x86_64-linux";
+        specialArgs = attrs;
+        modules = [
+          { system.name = sysname; }
+          ./nix/hosts/${sysname}/configuration.nix
+        ];
+      }
+    );
+  };
+}

--- a/nix/hosts/webforge/configuration.nix
+++ b/nix/hosts/webforge/configuration.nix
@@ -1,0 +1,16 @@
+{ ... }: {
+  imports = [
+    ./hardware-configuration.nix
+    ./networking.nix # generated at runtime by nixos-infect
+  ];
+
+  boot.tmp.cleanOnBoot = true;
+  zramSwap.enable = true;
+  networking.hostName = "webforge";
+  networking.domain = "";
+  services.openssh.enable = true;
+  users.users.root.openssh.authorizedKeys.keys = [
+    "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIJlPneIaRT/mqu13N83ctEftub4O6zAfi6qgzZKerU5o florian@leastauthority.com"
+    "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIIZtWY7t8HVnaz6bluYsrAlzZC3MZtb8g0nO5L5fCQKR benoit@leastauthority.com" ];
+  system.stateVersion = "23.11";
+}

--- a/nix/hosts/webforge/hardware-configuration.nix
+++ b/nix/hosts/webforge/hardware-configuration.nix
@@ -1,0 +1,8 @@
+{ modulesPath, ... }:
+{
+  imports = [ (modulesPath + "/profiles/qemu-guest.nix") ];
+  boot.loader.grub.device = "/dev/sda";
+  boot.initrd.availableKernelModules = [ "ata_piix" "uhci_hcd" "xen_blkfront" "vmw_pvscsi" ];
+  boot.initrd.kernelModules = [ "nvme" ];
+  fileSystems."/" = { device = "/dev/sda1"; fsType = "ext4"; };
+}

--- a/nix/hosts/webforge/networking.nix
+++ b/nix/hosts/webforge/networking.nix
@@ -1,0 +1,35 @@
+{ lib, ... }: {
+  # This file was populated at runtime with the networking
+  # details gathered from the active system.
+  networking = {
+    nameservers = [
+      "2a01:4ff:ff00::add:2"
+      "2a01:4ff:ff00::add:1"
+      "185.12.64.1"
+      "185.12.64.2"
+    ];
+    defaultGateway = "172.31.1.1";
+    defaultGateway6 = {
+      address = "fe80::1";
+      interface = "eth0";
+    };
+    dhcpcd.enable = false;
+    usePredictableInterfaceNames = lib.mkForce false;
+    interfaces = {
+      eth0 = {
+        ipv4.addresses = [
+          { address="135.181.155.146"; prefixLength=32; }
+        ];
+        ipv6.addresses = [
+          { address="2a01:4f9:c011:b882::1"; prefixLength=64; }
+          { address="fe80::9400:4ff:fe03:57eb"; prefixLength=64; }
+        ];
+        ipv4.routes = [ { address = "172.31.1.1"; prefixLength = 32; } ];
+        ipv6.routes = [ { address = "fe80::1"; prefixLength = 128; } ];
+      };
+    };
+  };
+  services.udev.extraRules = ''
+    ATTR{address}=="96:00:04:03:57:eb", NAME="eth0"
+  '';
+}


### PR DESCRIPTION
Fixes #31

Can be:
- tested with:
  ```
  nix flake check
  ```
- build with:
  ```
  nix build .#nixosConfigurations.webforge.config.system.build.toplevel
  ```
- further tested with:
  ```
  nixos-rebuild dry-activate --flake .#webforge --target-host root@webforge.tahoe-lafs.org
  ```

- deployed with:
  ```
  nixos-rebuild dry-activate --flake .#webforge --target-host root@webforge.tahoe-lafs.org
  ```

Edits:

1. The above commands requires this entry in the `known_hosts`:
    ```
    webforge.tahoe-lafs.org,135.181.155.146,2a01:4f9:c011:b882::1 ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIKPX87odbiiSbMyxb2N0curagHWUqSDPBG/P6bQcVzjJ
    ```
2. For an additional 99 LoC, we could have CI here too:

   - #33

    I'll leave it to the reviewer to choose