### PR TITLE
Only have one git around - the one the system depends on anyway

### DIFF
--- a/testgrid.tahoe-lafs.org/system-configuration.nix
+++ b/testgrid.tahoe-lafs.org/system-configuration.nix
@@ -37,7 +37,7 @@
   environment.systemPackages = with pkgs;
     [
       # Let us check out and update the system configuration repository.
-      git
+      gitMinimal
     ];
 
   # Keep log file disk usage in check.


### PR DESCRIPTION
I noticed today we had two installations of Git on this system - a 'minimal' one and one with modules we don't use and documentation we don't read.
Change our config to also depend on the 'minimal' variant.