### PR TITLE
Keep less old software around

### DIFF
--- a/testgrid.tahoe-lafs.org/system-configuration.nix
+++ b/testgrid.tahoe-lafs.org/system-configuration.nix
@@ -29,7 +29,7 @@
     automatic = true;
     dates = "weekly";
     randomizedDelaySec = "45min";
-    options = "--delete-older-than 14d";
+    options = "--delete-older-than 7d";
   };
 
   # List packages installed in system profile. To search, run:


### PR DESCRIPTION
With auto upgrades enabled, we get a new nixpkgs (>400 mb on disk) every single day.