### PR TITLE
[DO NOT MERGE] Manage all records in tahoe-lafs.org zone on Hetzner with Tofu

### DIFF
--- a/tf/core/dns_of-tl-org.tf
+++ b/tf/core/dns_of-tl-org.tf
@@ -1,30 +1,3 @@
-# Hetzner does not support zone for sub-domain like
-# `of.tahoe-lafs.org`, so we need to start from the parent
-# even if we want to manage only the sub one here
-
-# DNS zone for tahoe-lafs.org
-# with 1-hour TTL to support migration
-resource "hetznerdns_zone" "tl-org" {
-  name = "tahoe-lafs.org"
-  ttl  = 3600
-}
-
-# NS records of the zone
-resource "hetznerdns_record" "tl-org_ns" {
-  for_each = {
-    primary   = "hydrogen.ns.hetzner.com."
-    secondary = "oxygen.ns.hetzner.com."
-    tertiary  = "helium.ns.hetzner.de."
-  }
-
-  name    = "@"
-  type    = "NS"
-  value   = each.value
-  zone_id = hetznerdns_zone.tl-org.id
-}
-# TODO: Move the above in a separate `dns_tl-org.tf` file
-# when/if we end up managing the full zone
-
 # Here under should come records in `of.tahoe-lafs.org` only
 resource "hetznerdns_record" "tl-org-of_webforge_ipv4" {
   name    = "webforge.of"

--- a/tf/core/dns_tl-org.tf
+++ b/tf/core/dns_tl-org.tf
@@ -49,6 +49,20 @@ resource "hetznerdns_record" "tl-org_ipv4" {
   zone_id = hetznerdns_zone.tl-org.id
 }
 
+# Delegation for tahoeperf sub-domain
+resource "hetznerdns_record" "tl-org_perf" {
+  for_each = {
+    primary   = "ns-cloud1.googledomains.com."
+    secondary = "ns-cloud2.googledomains.com."
+  }
+
+  name    = "tahoeperf"
+  type    = "NS"
+  value   = each.value
+  ttl     = hetznerdns_zone.tl-org.ttl
+  zone_id = hetznerdns_zone.tl-org.id
+}
+
 # Web landing page
 resource "hetznerdns_record" "tl-org_www" {
   name    = "www"
@@ -74,6 +88,24 @@ resource "hetznerdns_record" "tl-org_lists" {
   name    = "lists"
   type    = upper(split("-", each.key)[0])
   value   = each.value
+  ttl     = hetznerdns_zone.tl-org.ttl
+  zone_id = hetznerdns_zone.tl-org.id
+}
+
+# Buildmaster
+resource "hetznerdns_record" "tl-org_buildmaster" {
+  name    = "buildmaster"
+  type    = "CNAME"
+  value   = "tahoe-lafs.org."
+  ttl     = hetznerdns_zone.tl-org.ttl
+  zone_id = hetznerdns_zone.tl-org.id
+}
+
+# Wormwhole
+resource "hetznerdns_record" "tl-org_wormhole" {
+  name    = "wormhole"
+  type    = "CNAME"
+  value   = "relay.magic-wormhole.io."
   ttl     = hetznerdns_zone.tl-org.ttl
   zone_id = hetznerdns_zone.tl-org.id
 }

--- a/tf/core/dns_tl-org.tf
+++ b/tf/core/dns_tl-org.tf
@@ -5,21 +5,46 @@ resource "hetznerdns_zone" "tl-org" {
   ttl  = 3600
 }
 
-# Root records of this zone
-resource "hetznerdns_record" "tl-org" {
+# NS records of the zone
+resource "hetznerdns_record" "tl-org_ns" {
   for_each = {
-    # <type>-<index> = <value>
-    ns-1  = "hydrogen.ns.hetzner.com.",
-    ns-2  = "oxygen.ns.hetzner.com.",
-    ns-3  = "helium.ns.hetzner.de.",
-    mx-1  = "50 tahoe-lafs.org.",
-    txt-1 = "v=spf1 ip4:74.207.252.227/32",
-    a-1   = "74.207.252.227"
+    primary   = "hydrogen.ns.hetzner.com."
+    secondary = "oxygen.ns.hetzner.com."
+    tertiary  = "helium.ns.hetzner.de."
   }
 
   name    = "@"
-  type    = upper(split("-", each.key)[0])
+  type    = "NS"
   value   = each.value
+  ttl     = hetznerdns_zone.tl-org.ttl
+  zone_id = hetznerdns_zone.tl-org.id
+}
+
+# Other root records of this zone
+resource "hetznerdns_record" "tl-org_mx" {
+  for_each = toset([
+    "50 tahoe-lafs.org.",
+  ])
+
+  name    = "@"
+  type    = "MX"
+  value   = each.value
+  ttl     = hetznerdns_zone.tl-org.ttl
+  zone_id = hetznerdns_zone.tl-org.id
+}
+
+resource "hetznerdns_record" "tl-org_spf1" {
+  name    = "@"
+  type    = "MX"
+  value   = "v=spf1 ip4:74.207.252.227/32"
+  ttl     = hetznerdns_zone.tl-org.ttl
+  zone_id = hetznerdns_zone.tl-org.id
+}
+
+resource "hetznerdns_record" "tl-org_ipv4" {
+  name    = "@"
+  type    = "A"
+  value   = "74.207.252.227"
   ttl     = hetznerdns_zone.tl-org.ttl
   zone_id = hetznerdns_zone.tl-org.id
 }

--- a/tf/core/dns_tl-org.tf
+++ b/tf/core/dns_tl-org.tf
@@ -1,0 +1,51 @@
+# DNS zone for tahoe-lafs.org
+# with 1-hour TTL to support migration
+resource "hetznerdns_zone" "tl-org" {
+  name = "tahoe-lafs.org"
+  ttl  = 3600
+}
+
+# Root records of this zone
+resource "hetznerdns_record" "tl-org" {
+  for_each = {
+    # <type>-<index> = <value>
+    ns-1  = "hydrogen.ns.hetzner.com.",
+    ns-2  = "oxygen.ns.hetzner.com.",
+    ns-3  = "helium.ns.hetzner.de.",
+    mx-1  = "50 tahoe-lafs.org.",
+    txt-1 = "v=spf1 ip4:74.207.252.227/32",
+    a-1   = "74.207.252.227"
+  }
+
+  name    = "@"
+  type    = upper(split("-", each.key)[0])
+  value   = each.value
+  ttl     = hetznerdns_zone.tl-org.ttl
+  zone_id = hetznerdns_zone.tl-org.id
+}
+
+# Web landing page
+resource "hetznerdns_record" "tl-org_www" {
+  name    = "www"
+  type    = "CNAME"
+  value   = "tahoe-lafs.org."
+  ttl     = hetznerdns_zone.tl-org.ttl
+  zone_id = hetznerdns_zone.tl-org.id
+}
+
+# Testgrid - trac#4160
+resource "hetznerdns_record" "tl-org_testgrid_ipv4" {
+  name    = "testgrid"
+  type    = "A"
+  value   = hcloud_server.testgrid.ipv4_address
+  ttl     = hetznerdns_zone.tl-org.ttl
+  zone_id = hetznerdns_zone.tl-org.id
+}
+
+resource "hetznerdns_record" "tl-org_testgrid_ipv6" {
+  name    = "testgrid"
+  type    = "AAAA"
+  value   = hcloud_server.testgrid.ipv6_address
+  ttl     = hetznerdns_zone.tl-org.ttl
+  zone_id = hetznerdns_zone.tl-org.id
+}

--- a/tf/core/dns_tl-org.tf
+++ b/tf/core/dns_tl-org.tf
@@ -33,6 +33,26 @@ resource "hetznerdns_record" "tl-org_www" {
   zone_id = hetznerdns_zone.tl-org.id
 }
 
+# Mailing lists
+resource "hetznerdns_record" "tl-org_lists" {
+  for_each = {
+    # <type>-<index> = <value>
+    mx-1   = "5 smtp1.osuosl.org.",
+    mx-2   = "5 smtp2.osuosl.org.",
+    mx-3   = "5 smtp3.osuosl.org.",
+    mx-4   = "5 smtp4.osuosl.org.",
+    txt-1  = "v=spf1 mx include:_spf.osuosl.org ~all",
+    a-1    = "140.211.9.53"
+    aaaa-1 = "2605:bc80:3010:104::8cd3:935"
+  }
+
+  name    = "lists"
+  type    = upper(split("-", each.key)[0])
+  value   = each.value
+  ttl     = hetznerdns_zone.tl-org.ttl
+  zone_id = hetznerdns_zone.tl-org.id
+}
+
 # Testgrid - trac#4160
 resource "hetznerdns_record" "tl-org_testgrid_ipv4" {
   name    = "testgrid"


### PR DESCRIPTION
Closes of #56

This PR is completing the provisioning of the DNS zone for `tahoe-lafs.org` hosted by Hetzner with all its existing records.

Once deployed, nothing will actually change for the users on internet. But this new zone will allow for a smooth transition if/when the delegation will be changed from Gandi: see [trac#4162](https://tahoe-lafs.org/trac/tahoe-lafs/ticket/4162) for more info.

Hopefully, this will help to make progress on a few open issues, starting with the ones related to [MoveOffTrac](https://github.com/tahoe-lafs/MoveOffTrac):

- #44
- #45 

**NOTES**:

- We still need a separate issue to deal properly with the credentials used to interact with Hetzner (user, password, 2FA and token).