### PR TITLE
Enable Nginx on webforge with basic settings and open the firewall

### DIFF
--- a/nix/hosts/webforge/configuration.nix
+++ b/nix/hosts/webforge/configuration.nix
@@ -11,7 +11,7 @@
   # Enable firewall with the required ports
   networking.firewall = {
     enable = true;
-    allowPing = false;
+    allowPing = true;
     allowedTCPPorts = [
       80
       443
@@ -19,6 +19,7 @@
     allowedUDPPorts = [
       443
     ];
+    rejectPackets = true;
   };
 
   # Enable Nginx with common settings

--- a/nix/hosts/webforge/configuration.nix
+++ b/nix/hosts/webforge/configuration.nix
@@ -8,5 +8,32 @@
   networking.hostName = "webforge";
   networking.domain = "tahoe-lafs.org";
 
+  # Enable firewall with the required ports
+  networking.firewall = {
+    enable = true;
+    allowPing = false;
+    allowedTCPPorts = [
+      80
+      443
+    ];
+    allowedUDPPorts = [
+      443
+    ];
+  };
+
+  # Enable Nginx with common settings
+  services.nginx = {
+    enable = true;
+
+    # Apply recommended settings
+    recommendedGzipSettings = true;
+    recommendedOptimisation = true;
+    recommendedProxySettings = true;
+    recommendedTlsSettings = true;
+
+    # Only allow PFS-enabled ciphers with AES256:
+    sslCiphers = "AES256+EECDH:AES256+EDH:!aNULL";
+  };
+
   system.stateVersion = "23.11";
 }


### PR DESCRIPTION
Part of #45 

Just enable Nginx with basic settings and open the firewall accordingly.