### PR TITLE
Nixfmt this so it's easier to diff against nixpkgs proper

### DIFF
--- a/testgrid.tahoe-lafs.org/access-control.nix
+++ b/testgrid.tahoe-lafs.org/access-control.nix
@@ -1,4 +1,5 @@
-{ ... }: {
+{ ... }:
+{
   # Initial empty root password for easy login:
   users.users.root.initialHashedPassword = "";
   services.openssh.settings.PermitRootLogin = "prohibit-password";

--- a/testgrid.tahoe-lafs.org/configuration.nix
+++ b/testgrid.tahoe-lafs.org/configuration.nix
@@ -1,4 +1,5 @@
-{ ... }: {
+{ ... }:
+{
   imports = [
     # Set options intended for a "small" NixOS: Do not build X and docs.
     <nixpkgs/nixos/modules/profiles/minimal.nix>

--- a/testgrid.tahoe-lafs.org/hardware-configuration.nix
+++ b/testgrid.tahoe-lafs.org/hardware-configuration.nix
@@ -11,11 +11,16 @@
 # VM and need a new hardware configuration for it - unless it happens to be
 # configured just like this one, which it might be).
 
-{ modulesPath, ... }: {
+{ modulesPath, ... }:
+{
   imports = [ (modulesPath + "/profiles/qemu-guest.nix") ];
   boot.loader.grub.device = "/dev/sda";
-  boot.initrd.availableKernelModules =
-    [ "ata_piix" "uhci_hcd" "xen_blkfront" "vmw_pvscsi" ];
+  boot.initrd.availableKernelModules = [
+    "ata_piix"
+    "uhci_hcd"
+    "xen_blkfront"
+    "vmw_pvscsi"
+  ];
   boot.initrd.kernelModules = [ "nvme" ];
   fileSystems."/" = {
     device = "/dev/sda1";

--- a/testgrid.tahoe-lafs.org/networking.nix
+++ b/testgrid.tahoe-lafs.org/networking.nix
@@ -1,4 +1,5 @@
-{ lib, ... }: {
+{ lib, ... }:
+{
   # This file was populated at runtime with the networking
   # details gathered from the active system.
   networking = {
@@ -6,8 +7,11 @@
     hostName = "testgrid";
     domain = "tahoe-lafs.org";
 
-    nameservers =
-      [ "2a01:4ff:ff00::add:1" "2a01:4ff:ff00::add:2" "185.12.64.2" ];
+    nameservers = [
+      "2a01:4ff:ff00::add:1"
+      "2a01:4ff:ff00::add:2"
+      "185.12.64.2"
+    ];
     defaultGateway = "172.31.1.1";
     defaultGateway6 = {
       address = "fe80::1";
@@ -17,10 +21,12 @@
     usePredictableInterfaceNames = lib.mkForce false;
     interfaces = {
       eth0 = {
-        ipv4.addresses = [{
-          address = "37.27.215.216";
-          prefixLength = 32;
-        }];
+        ipv4.addresses = [
+          {
+            address = "37.27.215.216";
+            prefixLength = 32;
+          }
+        ];
         ipv6.addresses = [
           {
             address = "2a01:4f9:c010:d906::1";
@@ -31,14 +37,18 @@
             prefixLength = 64;
           }
         ];
-        ipv4.routes = [{
-          address = "172.31.1.1";
-          prefixLength = 32;
-        }];
-        ipv6.routes = [{
-          address = "fe80::1";
-          prefixLength = 128;
-        }];
+        ipv4.routes = [
+          {
+            address = "172.31.1.1";
+            prefixLength = 32;
+          }
+        ];
+        ipv6.routes = [
+          {
+            address = "fe80::1";
+            prefixLength = 128;
+          }
+        ];
       };
 
     };

--- a/testgrid.tahoe-lafs.org/system-configuration.nix
+++ b/testgrid.tahoe-lafs.org/system-configuration.nix
@@ -34,11 +34,10 @@
 
   # List packages installed in system profile. To search, run:
   # $ nix search wget
-  environment.systemPackages = with pkgs;
-    [
-      # Let us check out and update the system configuration repository.
-      gitMinimal
-    ];
+  environment.systemPackages = with pkgs; [
+    # Let us check out and update the system configuration repository.
+    gitMinimal
+  ];
 
   # We aren't interested in old logs.
   services.journald.extraConfig = ''

--- a/testgrid.tahoe-lafs.org/tahoe-lafs-testgrid.nix
+++ b/testgrid.tahoe-lafs.org/tahoe-lafs-testgrid.nix
@@ -8,9 +8,10 @@ let
   # The package from nixpkgs:
   #   package = pkgs.tahoe-lafs;
   # The upstream flake:
-  package = (builtins.getFlake
-    "github:tahoe-lafs/tahoe-lafs?ref=master").packages.x86_64-linux.default;
-in {
+  package =
+    (builtins.getFlake "github:tahoe-lafs/tahoe-lafs?ref=master").packages.x86_64-linux.default;
+in
+{
   # Configure Tahoe to run here.
   services.tahoe = {
 
@@ -35,42 +36,44 @@ in {
     # client.  On a more realistic deployment these would all be run
     # separately from other to make their failure modes as independent as
     # possible.
-    nodes = let
-      # XXX NixOS module doesn't support multi-introducer configuration.
-      introducer = "pb://flm2vcjxaxoyah3f2ufdk74augada55i@tcp:testgrid.tahoe-lafs.org:5000/s3kbdgg3j4ohifa633tt7yi25drl6jqa";
-    in {
-      alpha = {
-        inherit package;
-        nickname = "alpha-storage";
-        # XXX NixOS module requires we configure a web port even if we don't
-        # want one.
-        web.port = 2002;
-        storage.enable = true;
-        tub.location = "${config.networking.fqdn}:5002";
-        tub.port = 5002;
-        client.introducer = introducer;
+    nodes =
+      let
+        # XXX NixOS module doesn't support multi-introducer configuration.
+        introducer = "pb://flm2vcjxaxoyah3f2ufdk74augada55i@tcp:testgrid.tahoe-lafs.org:5000/s3kbdgg3j4ohifa633tt7yi25drl6jqa";
+      in
+      {
+        alpha = {
+          inherit package;
+          nickname = "alpha-storage";
+          # XXX NixOS module requires we configure a web port even if we don't
+          # want one.
+          web.port = 2002;
+          storage.enable = true;
+          tub.location = "${config.networking.fqdn}:5002";
+          tub.port = 5002;
+          client.introducer = introducer;
+        };
+        beta = {
+          inherit package;
+          nickname = "beta-storage";
+          # XXX
+          web.port = 2003;
+          storage.enable = true;
+          tub.location = "${config.networking.fqdn}:5003";
+          tub.port = 5003;
+          client.introducer = introducer;
+        };
+        gamma = {
+          inherit package;
+          nickname = "gamma-storage";
+          # XXX
+          web.port = 2004;
+          storage.enable = true;
+          tub.location = "${config.networking.fqdn}:5004";
+          tub.port = 5004;
+          client.introducer = introducer;
+        };
       };
-      beta = {
-        inherit package;
-        nickname = "beta-storage";
-        # XXX
-        web.port = 2003;
-        storage.enable = true;
-        tub.location = "${config.networking.fqdn}:5003";
-        tub.port = 5003;
-        client.introducer = introducer;
-      };
-      gamma = {
-        inherit package;
-        nickname = "gamma-storage";
-        # XXX
-        web.port = 2004;
-        storage.enable = true;
-        tub.location = "${config.networking.fqdn}:5004";
-        tub.port = 5004;
-        client.introducer = introducer;
-      };
-    };
   };
 
   # The current nixpkgs service definition isn't compatible with the upstream

--- a/testgrid.tahoe-lafs.org/tahoe-service.nix
+++ b/testgrid.tahoe-lafs.org/tahoe-service.nix
@@ -214,9 +214,7 @@ in
           description = "Tahoe LAFS node ${node}";
           wantedBy = [ "multi-user.target" ];
           path = [ settings.package ];
-          restartTriggers = [
-            config.environment.etc."tahoe-lafs/introducer-${node}.cfg".source
-          ];
+          restartTriggers = [ config.environment.etc."tahoe-lafs/introducer-${node}.cfg".source ];
           serviceConfig = {
             Type = "simple";
             # Believe it or not, Tahoe is very brittle about the order of
@@ -266,8 +264,7 @@ in
         }
       );
       users.groups = lib.flip lib.mapAttrs' cfg.introducers (
-        node: _:
-        lib.nameValuePair "tahoe.introducer-${node}" { }
+        node: _: lib.nameValuePair "tahoe.introducer-${node}" { }
       );
     })
     (lib.mkIf (cfg.nodes != { }) {
@@ -335,9 +332,7 @@ in
           description = "Tahoe LAFS node ${node}";
           wantedBy = [ "multi-user.target" ];
           path = [ settings.package ];
-          restartTriggers = [
-            config.environment.etc."tahoe-lafs/${node}.cfg".source
-          ];
+          restartTriggers = [ config.environment.etc."tahoe-lafs/${node}.cfg".source ];
           serviceConfig = {
             Type = "simple";
             # The comments for the introducer ExecStart config above apply here as well.
@@ -371,10 +366,7 @@ in
           home = "/var/db/tahoe-lafs/${node}";
         }
       );
-      users.groups = lib.flip lib.mapAttrs' cfg.nodes (
-        node: _:
-        lib.nameValuePair "tahoe.${node}" { }
-      );
+      users.groups = lib.flip lib.mapAttrs' cfg.nodes (node: _: lib.nameValuePair "tahoe.${node}" { });
     })
   ];
 }


### PR DESCRIPTION
The tahoe systemd service definition in Nixpkgs, that I want to update with our improvements, has been formatted in https://github.com/NixOS/nixpkgs/commit/4f0dadbf38ee4cf4cc38cbc232b7708fddf965bc.
Do the same step here so I the diff is less noisy and we're up to the RFC nix style.

----

Command used:
  nix-shell -p nixfmt-rfc-style --command "nixfmt --strict *.nix"

This is so I have an easier time merging our improvements to the nixpkgs tahoe systemd unit definition.