### PR TITLE
Add missing CNAME for the legacy proxy vhost

### DIFF
--- a/tf/core/dns_of-tl-org.tf
+++ b/tf/core/dns_of-tl-org.tf
@@ -47,6 +47,7 @@ resource "hetznerdns_record" "tl-org-of_webforge_aliases" {
   for_each = toset([
     "forge",
     "home",
+    "legacy",
     "preview",
   ])
 


### PR DESCRIPTION
This legacy virtual host name has been overlooked in #64 

See https://github.com/tahoe-lafs/infrastructure/pull/64#discussion_r2098024496