### PR TITLE
Ignore cloud-init changes to avoid server destruction

### DIFF
--- a/tf/core/srv_testgrid.tf
+++ b/tf/core/srv_testgrid.tf
@@ -26,9 +26,9 @@ EOF
   ]
   lifecycle {
     ignore_changes = [
-      # Ignore some changes post installation
-      user_data,
+      # Ignore some post installation changes
       ssh_keys,
+      user_data,
     ]
   }
 }

--- a/tf/core/srv_webforge.tf
+++ b/tf/core/srv_webforge.tf
@@ -26,8 +26,9 @@ EOF
   ]
   lifecycle {
     ignore_changes = [
-      # Ignore changes to ssh_keys post installation
+      # Ignore some post installation changes
       ssh_keys,
+      user_data,
     ]
   }
 }


### PR DESCRIPTION
This PR prevents the destruction of the VPS  whenever the cloud-init data are changed.