### PR TITLE
Backup the correct website folder from webforge

### DIFF
--- a/nix/hosts/webforge/backup.nix
+++ b/nix/hosts/webforge/backup.nix
@@ -18,7 +18,7 @@
       "cmd_postexec	" + ./backup_postexec.sh + "\n" +
       "backup	" + config.mailserver.dkimKeyDirectory + "	opendkim_keys/\n" +
       "backup	" + "/var/lib/postfix/queue" + "	postfix_queue/\n" +
-      "backup	" + "/srv/www" + "	www_sites/\n" +
+      "backup	" + "/var/www" + "	www_sites/\n" +
       "backup	" + config.services.forgejo.stateDir + "	forgejo_data/\n" +
       "backup_script	" + ./backup_pgsql.sh + "	postgres/\n";
   };


### PR DESCRIPTION
Completes #73 

After verifying the daily backup on `webforge`, I've found an error in the logs.
This PRs fixes the wrong directory and has been manualy tested with success:

```
[root@webforge:/var/tmp]# ls -lA /var/rsnapshot/daily.0/
total 20
drwx------ 3 root root 4096 Jun 26 15:53 forgejo_data
drwx------ 3 root root 4096 Jun 26 15:53 opendkim_keys
drwx------ 3 root root 4096 Jun 26 15:53 postfix_queue
drwx------ 2 root root 4096 Jun 26 15:53 postgres
drwx------ 3 root root 4096 Jun 26 15:53 www_sites

[root@webforge:/var/tmp]# du -sh /var/rsnapshot/daily.0/
57M     /var/rsnapshot/daily.0/
```
