### PR TITLE
Add a local forgejo-runner to support CI/CD

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -80,11 +80,11 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1752950548,
-        "narHash": "sha256-NS6BLD0lxOrnCiEOcvQCDVPXafX1/ek1dfJHX1nUIzc=",
+        "lastModified": 1754725699,
+        "narHash": "sha256-iAcj9T/Y+3DBy2J0N+yF9XQQQ8IEb5swLFzs23CdP88=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "c87b95e25065c028d31a94f06a62927d18763fdf",
+        "rev": "85dbfc7aaf52ecb755f87e577ddbe6dbbdbc1054",
         "type": "github"
       },
       "original": {

--- a/nix/hosts/webforge/configuration.nix
+++ b/nix/hosts/webforge/configuration.nix
@@ -7,6 +7,7 @@
     ./backup.nix
     ./web-landing-page.nix
     ./forgejo.nix
+    ./forgejo-runner.nix
     ./mailserver.nix
     ./postgresql.nix
   ];

--- a/nix/hosts/webforge/forgejo-runner.nix
+++ b/nix/hosts/webforge/forgejo-runner.nix
@@ -1,0 +1,61 @@
+{ pkgs, config, ... }: {
+
+  sops = {
+    secrets = {
+      forgejo-runner-local1-token = {
+        # Because the gitea-runner user and group are dynamic,
+        # we can not use those in our config!
+        # https://github.com/NixOS/nixpkgs/blob/90bd1b26e23760742fdcb6152369919098f05417/nixos/modules/services/continuous-integration/gitea-actions-runner.nix#L211
+        # Though, this secret is used only once to register the runner
+        mode = "0444";
+      };
+    };
+  };
+
+  # Enable docker to host a local runner
+  virtualisation.docker.enable = true;
+  # Ensure the local runner can reach this server to register
+  # while avoiding localhost:3000 which will not work inside containers
+  networking.hosts = {
+    "127.0.0.2" = [ "forge.of.tahoe-lafs.org" ];
+  };
+  services.gitea-actions-runner = {
+    # Use the forgejo fork
+    # TODO switch from unstable to stable with 25.05
+    package = pkgs.unstable.forgejo-runner;
+    instances = {
+      # A local runner which should be carefully registered at org. level,
+      # so only users with write/push permissions on org. repos can mess with it
+      # TODO: spin a dedicated instance as recommended instead
+      "local1" = {
+        enable = true;
+        url = config.services.forgejo.settings.server.ROOT_URL;
+        name = "local1";
+        tokenFile = config.sops.secrets.forgejo-runner-local1-token.path;
+        labels = [
+          # provide a debian base with nodejs for actions
+          "lts-bookworm-slim:docker://node:lts-bookworm-slim"
+          # provide same image with python
+          "lts-bookworm:docker://node:lts-bookworm"
+          # provide default images based on catthehacker/ubuntu:act-*
+          # wich contain most of the tools needed to run workflows
+          "ubuntu-latest:docker://gitea/runner-images:ubuntu-latest"
+          "ubuntu-22.04:docker://gitea/runner-images:ubuntu-22.04"
+          "ubuntu-20.04:docker://gitea/runner-images:ubuntu-20.04"
+        ];
+        settings = {
+          container = {
+            # Mount the socket of the docker host to run docker-in-docker
+            options = "--mount type=bind,src=/var/run/docker.sock,dst=/var/run/docker.sock";
+            valid_volumes = [
+              "/var/run/docker.sock"
+            ];
+          };
+        };
+      };
+    };
+  };
+  # Allow rw access from runner to the socket of the docker host
+  # TODO: migrate this runner on a dedicated host!
+  systemd.services."gitea-runner-local1".serviceConfig.ReadWritePaths="/var/run/docker.sock";
+}

--- a/secrets/webforge.yaml
+++ b/secrets/webforge.yaml
@@ -1,0 +1,52 @@
+forgejo-runner-local1-token: ENC[AES256_GCM,data:6VSagqhzSxbxTgV6QaQyfskTlW/pU8riEA4eLeszk4bCa6TDvi9BKG6Vo59ZMw==,iv:ug5KTsai3Rxf7R7U8v1UU1NGIvNjrHLg+RPmhFGytwE=,tag:3sfsLPMWDIH3WKpclOJlWg==,type:str]
+sops:
+    kms: []
+    gcp_kms: []
+    azure_kv: []
+    hc_vault: []
+    age: []
+    lastmodified: "2025-05-09T21:29:36Z"
+    mac: ENC[AES256_GCM,data:VRhV/BYDkAnDYbX5t+3p5TkYb/NThsukBcAK1+t+Z5SvdaK4UrSJ01sLctHx6uJcLQJszDCQApHlZZbSWfDhKsLWSQgN3wdYhVYwMIXwkge06oKXh2ulufZnIGl0YNWNpCnNirbcGDd3/GDt5H08N99aEDdYDLuUMzI5/+Lg+YU=,iv:n2rNXAEjf0k7cTq+ckGdnAr0422Y/1B8nlTUmmhbK7k=,tag:CxMaSBO9B15r8GVJRE5iMA==,type:str]
+    pgp:
+        - created_at: "2025-01-27T08:46:45Z"
+          enc: |-
+            -----BEGIN PGP MESSAGE-----
+
+            hF4D7tu0ZynG8wUSAQdAE6R7NcSnCjS1EyhjQGgQDLDppB+Ec3EUW+4grTp6ByQw
+            U91X9uPx++Nk5cglEqzwuHobpPlI9o/fCFAx7IgGvf5NVAgXBQnnoKFHr+Tcnsvt
+            0l4BJ9phmXjYE8tV+tmD23g60hlkv0+2axU7HPTaCZDJ8e7mpKijKL2+58XTLMSH
+            9twS4vejd3Q9pv7wg5Nz9FsadnFMcRVHQ/t22cuNJJiOEhRwlwd9iD/3a1LocVuT
+            =Mp+M
+            -----END PGP MESSAGE-----
+          fp: 411eb16d13b422490feba1155a7a09f0c279fcd6
+        - created_at: "2025-01-27T08:46:45Z"
+          enc: |-
+            -----BEGIN PGP MESSAGE-----
+
+            hF4DVyinnm39Oc8SAQdAY0pGBX3MluKAy8kWBfJdydug23UzXKTdhdbHAR8xwwEw
+            jcGesv2oTBjJQ2mWFT8vr+UOr/ApnomMd7Y1Y6ma69CRqyTIwzm3p0S/p+ExGsqe
+            0l4B6+HjoxfpW3QESplh7zh80Hfd+FQkqaplgHNNxc6MRIoWoCegh2yfkpDb70Mj
+            vZ0VmnFi/MJ5wmg4tDDlCnIzPVmiOnvYAPzChirW0HF+VxiHeEv9TefuUH5n2a0Q
+            =5CQw
+            -----END PGP MESSAGE-----
+          fp: 5244970fbec8aa66658ec4b6d7d4a441431a73f1
+        - created_at: "2025-01-27T08:46:45Z"
+          enc: |-
+            -----BEGIN PGP MESSAGE-----
+
+            hQGMA5wVnlCD0O1kAQv8CR8wTK+Y4NRFYsJHde0DU7ZeHH8cm1Pjq1anqaXhatDE
+            8ZHhKxmKKgd+jq5KZW3nhsWM2cSepUwkh+67V1xEgvuxOfebKd/IVsqHHd8Qj3lq
+            zF8KYImYt7NFJhRxPKGSWI5X3LXccamo7ab4pxgLRj6SwPjfLibxfCAqTnfM7WIQ
+            vdIJfZxsqFU6lhyncnE34Y+zfR9f6a519dV7u3Qxn4g7LvPuoKmBvRqYeV4FR2hn
+            WSq0vYR2mdZJsWyzq1K/UmSuhsVW2YkAc2sfkVNPETliW7jPKWi8Qb8unffimor5
+            bzmGcHGRniraz9xpIRnbTh4PnP7VySNXXwtxag9Hse+FMoiEpQ7vzUl3dJ/MYOfF
+            6d4YJ5svdDIzNS0LzAe3x28CJ8YXa1nb9qrCenZcz8yJ1p3w4QU7w1U8IaUbuUjw
+            jQAoMUifNbuLcqJ47s82L9n6s2TtoOhQrkzuLlN/K5twUn3eq93IZUfv+onYlqIX
+            w6NiqVGJg3iIC0MWhw6c0lgBEtZr2xMXEGDjZLKFhp/sYTkiB/aHfqv/KanddRHo
+            okzFzUWjw7bgTs6RA1JJ3LYGUat6+ATUXJvTGNN9EgUFFPkj6w97/UF/CEW36WjZ
+            dKkn8xf1fLtu
+            =zWSN
+            -----END PGP MESSAGE-----
+          fp: 122ace3a40ab7fc47e5659c29c159e5083d0ed64
+    unencrypted_suffix: _unencrypted
+    version: 3.9.2


### PR DESCRIPTION
Part of #44 and #45

We need a runner attached to the [web-landing-page](https://forge.of.tahoe-lafs.org/tahoe-lafs/web-landing-page) repository in order to integrate and deploy changes on the website via PR's.

Cons. or pros - depending on how to look at it:.

Waiting for a possible migration to GitHub, this is a pure self-hosted solution, with Forgejo and its own runner (albeit a local one).

In addition, there is now an automated "push-clone" mirroring configure from Forgejo to GitHub for that repo.