### PR TITLE
Improve admin emails

### DIFF
--- a/nix/common/default.nix
+++ b/nix/common/default.nix
@@ -56,4 +56,7 @@
     pkgs.unstable.ssh-to-pgp
     vim
   ];
+
+  # Silent cron email - connection is refused anyway
+  services.cron.mailto = "";
 }

--- a/nix/hosts/webforge/backup_pgsql.sh
+++ b/nix/hosts/webforge/backup_pgsql.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # Configure bash behavior
-set -o xtrace   # print every call to help debugging
+#set -o xtrace   # print every call to help debugging
 set -o errexit  # exit on failed command
 set -o nounset  # exit on undeclared variables
 set -o pipefail # exit on any failed command in pipes

--- a/nix/hosts/webforge/backup_postexec.sh
+++ b/nix/hosts/webforge/backup_postexec.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # Configure bash behavior
-set -o xtrace   # print every call to help debugging
+#set -o xtrace   # print every call to help debugging
 set -o errexit  # exit on failed command
 set -o nounset  # exit on undeclared variables
 set -o pipefail # exit on any failed command in pipes

--- a/nix/hosts/webforge/backup_preexec.sh
+++ b/nix/hosts/webforge/backup_preexec.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # Configure bash behavior
-set -o xtrace   # print every call to help debugging
+#set -o xtrace   # print every call to help debugging
 set -o errexit  # exit on failed command
 set -o nounset  # exit on undeclared variables
 set -o pipefail # exit on any failed command in pipes


### PR DESCRIPTION
I've found some deferred emails from cron in the journal of `webforge`.

Postfix tries to send them to the local agent, but using public IPs, which are blocked.

This change avoid debug messages in the cron job which are the root cause of those emails.
And prevent cron to send emails in any case.

If we want those email at some point, we will need to think about the whole flow.