### PR TITLE
Actually disabling the registration until migration

### DIFF
--- a/nix/hosts/webforge/forgejo.nix
+++ b/nix/hosts/webforge/forgejo.nix
@@ -66,7 +66,7 @@
         ROOT_URL = "https://forge.of.tahoe-lafs.org/";
       };
       service = {
-        DISABLE_REGISTER = true;         # only admin can register until the migration is completed
+        DISABLE_REGISTRATION = true;     # only admin can register until the migration is completed
         # REGISTER_EMAIL_CONFIRM = true; # when not registering via oauth2
         # ENABLE_CAPTCHA = true;         # to reduce spam registration
         # CAPTCHA_TYPE = "image";


### PR DESCRIPTION
As it turned out, registration was still opened because of a typo!

Let's close it until the migration day to avoid exiting Trac user to register with a different username.