### PR TITLE
[DO NO MERGE] Switch from Hetzner to deSec as DNS hosting provider

### DIFF
--- a/tf/core/dns_of-tl-org.tf
+++ b/tf/core/dns_of-tl-org.tf
@@ -1,106 +1,79 @@
-# Hetzner does not support zone for sub-domain like
-# `of.tahoe-lafs.org`, so we need to start from the parent
-# even if we want to manage only the sub one here
-
-# DNS zone for tahoe-lafs.org
-# with 1-hour TTL to support migration
-resource "hetznerdns_zone" "tl-org" {
-  name = "tahoe-lafs.org"
-  ttl  = 3600
-}
-
-# NS records of the zone
-resource "hetznerdns_record" "tl-org_ns" {
-  for_each = {
-    primary   = "hydrogen.ns.hetzner.com."
-    secondary = "oxygen.ns.hetzner.com."
-    tertiary  = "helium.ns.hetzner.de."
-  }
-
-  name    = "@"
-  type    = "NS"
-  value   = each.value
-  zone_id = hetznerdns_zone.tl-org.id
-}
-# TODO: Move the above in a separate `dns_tl-org.tf` file
-# when/if we end up managing the full zone
-
 # Here under should come records in `of.tahoe-lafs.org` only
-resource "hetznerdns_record" "tl-org-of_webforge_ipv4" {
-  name    = "webforge.of"
+resource "desec_rrset" "tl-org-of_webforge_ipv4" {
+  subname = "webforge.of"
   type    = "A"
-  value   = hcloud_server.webforge.ipv4_address
-  zone_id = hetznerdns_zone.tl-org.id
+  records = [hcloud_server.webforge.ipv4_address]
+  domain  = desec_domain.dns_tl-org.name
 }
 
-resource "hetznerdns_record" "tl-org-of_webforge_ipv6" {
-  name    = "webforge.of"
+resource "desec_rrset" "tl-org-of_webforge_ipv6" {
+  subname = "webforge.of"
   type    = "AAAA"
-  value   = hcloud_server.webforge.ipv6_address
-  zone_id = hetznerdns_zone.tl-org.id
+  records = [hcloud_server.webforge.ipv6_address]
+  domain  = desec_domain.dns_tl-org.name
 }
 
-resource "hetznerdns_record" "tl-org-of_webforge_aliases" {
+resource "desec_rrset" "tl-org-of_webforge_aliases" {
   for_each = toset([
     "home",
     "legacy",
     "preview",
   ])
 
-  name    = "${each.value}.of"
+  subname = "${each.value}.of"
   type    = "CNAME"
-  value   = "webforge.of"
+  records = ["webforge.of"]
   ttl     = "600"
-  zone_id = hetznerdns_zone.tl-org.id
+  domain  = desec_domain.dns_tl-org.name
 }
 
 # MX and TXT for forge.of forbid CNAME, so re-use the A/AAAA
-resource "hetznerdns_record" "tl-org-of_forge_ipv4" {
-  name    = "forge.of"
+resource "desec_rrset" "tl-org-of_forge_ipv4" {
+  subname = "forge.of"
   type    = "A"
-  value   = hcloud_server.webforge.ipv4_address
-  zone_id = hetznerdns_zone.tl-org.id
+  records = [hcloud_server.webforge.ipv4_address]
+  domain  = desec_domain.dns_tl-org.name
 }
 
-resource "hetznerdns_record" "tl-org-of_forge_ipv6" {
-  name    = "forge.of"
+resource "desec_rrset" "tl-org-of_forge_ipv6" {
+  subname = "forge.of"
   type    = "AAAA"
-  value   = hcloud_server.webforge.ipv6_address
-  zone_id = hetznerdns_zone.tl-org.id
+  records = [hcloud_server.webforge.ipv6_address]
+  domain  = desec_domain.dns_tl-org.name
 }
 
 # Better have an MX record to webforge, even if it will only send
-resource "hetznerdns_record" "tl-org-of_forge_mx" {
-  name    = "forge.of"
+resource "desec_rrset" "tl-org-of_forge_mx" {
+  subname = "forge.of"
   type    = "MX"
-  value   = "0 webforge.of.${hetznerdns_zone.tl-org.name}."
+  records = ["0 webforge.of.${hetznerdns_zone.tl-org.name}."]
   ttl     = "600"
-  zone_id = hetznerdns_zone.tl-org.id
+  domain  = desec_domain.dns_tl-org.name
 }
 
 # Explicitely authorize sending email from webforge IPs
-resource "hetznerdns_record" "tl-org-of_forge_spf" {
-  name    = "forge.of"
+resource "desec_rrset" "tl-org-of_forge_spf" {
+  subname = "forge.of"
   type    = "TXT"
-  value   = "v=spf1 a:webforge.of.${hetznerdns_zone.tl-org.name} -all"
+  records = ["v=spf1 a:webforge.of.${hetznerdns_zone.tl-org.name} -all"]
   ttl     = "600"
-  zone_id = hetznerdns_zone.tl-org.id
+  domain  = desec_domain.dns_tl-org.name
 }
 
 # Public DKIM keys used to sign emails send from webforge
-resource "hetznerdns_record" "tl-org-of_forge_dkim" {
-  name    = "mail._domainkey.forge.of"
+resource "desec_rrset" "tl-org-of_forge_dkim" {
+  subname = "mail._domainkey.forge.of"
   type    = "TXT"
-  value   = "v=DKIM1; k=rsa; p=MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQC/QgivKbeRtd1wETUE+DWCYzkNwFh6H/RfiyOEvzOW/lTU3CMc25T+/h6/5iHk0Kjxu8zdYB3n4llgeM28XSVuQBToedhL2p1X3UlJkMb+8Zm10o7aqBppUG+4MPCiqXwgTtk9FQq/s/iojIMrvyfNqdRYIsmmSZppfXIvEBYcEQIDAQAB"
+  records = ["v=DKIM1; k=rsa; p=MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQC/QgivKbeRtd1wETUE+DWCYzkNwFh6H/RfiyOEvzOW/lTU3CMc25T+/h6/5iHk0Kjxu8zdYB3n4llgeM28XSVuQBToedhL2p1X3UlJkMb+8Zm10o7aqBppUG+4MPCiqXwgTtk9FQq/s/iojIMrvyfNqdRYIsmmSZppfXIvEBYcEQIDAQAB"]
   ttl     = "600"
-  zone_id = hetznerdns_zone.tl-org.id
+  domain  = desec_domain.dns_tl-org.name
 }
 
 # Be a good citizen and catch DMARC reports (via Least Authority for now)
-resource "hetznerdns_record" "tl-org-of_forge_dmarc" {
-  name    = "_dmarc.forge.of"
+resource "desec_rrset" "tl-org-of_forge_dmarc" {
+  subname = "_dmarc.forge.of"
   type    = "TXT"
-  value   = "v=DMARC1; p=none; rua=mailto:tahoe@leastauthority.com"
+  records = ["v=DMARC1; p=none; rua=mailto:tahoe@leastauthority.com"]
   ttl     = "600"
-  zone_id = hetznerdns_zone.tl-org.id
+  domain  = desec_domain.dns_tl-org.name
 }

--- a/tf/core/dns_tl-org.tf
+++ b/tf/core/dns_tl-org.tf
@@ -1,0 +1,121 @@
+# DNS zone for tahoe-lafs.org
+# with 1-hour TTL to support migration
+resource "desec_domain" "dns_tl-org" {
+  name = "tahoe-lafs.org"
+  ttl  = 3600
+}
+
+# There is no way to get the data from the subdomain
+# Let's use a local variable instead
+locals {
+  dns_tl-org = {
+    nameservers = {
+      primary   = "ns1.desec.io."
+      secondary = "ns2.desec.org.",
+    }
+    ttl = 3600
+  }
+}
+
+# Other root records of this zone
+resource "desec_rrset" "tl-org_mx" {
+  subname = "@"
+  type    = "MX"
+  records = ["50 tahoe-lafs.org."]
+  ttl     = local.dns_tl-org.ttl
+  domain  = desec_domain.dns_tl-org.name
+}
+
+resource "desec_rrset" "tl-org_spf1" {
+  subname = "@"
+  type    = "TXT"
+  records = ["v=spf1 ip4:74.207.252.227/32"]
+  ttl     = local.dns_tl-org.ttl
+  domain  = local.dns_tl-org.name
+}
+
+resource "desec_rrset" "tl-org_ipv4" {
+  subname = "@"
+  type    = "A"
+  records = ["74.207.252.227"]
+  ttl     = local.dns_tl-org.ttl
+  domain  = local.dns_tl-org.name
+}
+
+# Delegation for tahoeperf sub-domain
+resource "desec_rrset" "tl-org_perf" {
+  for_each = {
+    primary   = "ns-cloud1.googledomains.com."
+    secondary = "ns-cloud2.googledomains.com."
+  }
+
+  subname = "tahoeperf"
+  type    = "NS"
+  records = [each.value]
+  ttl     = local.dns_tl-org.ttl
+  domain  = desec_domain.dns_tl-org.name
+}
+
+# Web landing page
+resource "desec_rrset" "tl-org_www" {
+  subname = "www"
+  type    = "CNAME"
+  records = ["tahoe-lafs.org."]
+  ttl     = local.dns_tl-org.ttl
+  domain  = desec_domain.dns_tl-org.name
+}
+
+# Mailing lists
+resource "desec_rrset" "tl-org_lists" {
+  for_each = {
+    # <type>-<index> = <value>
+    mx-1   = "5 smtp1.osuosl.org.",
+    mx-2   = "5 smtp2.osuosl.org.",
+    mx-3   = "5 smtp3.osuosl.org.",
+    mx-4   = "5 smtp4.osuosl.org.",
+    txt-1  = "v=spf1 mx include:_spf.osuosl.org ~all",
+    a-1    = "140.211.9.53"
+    aaaa-1 = "2605:bc80:3010:104::8cd3:935"
+  }
+
+  subname = "lists"
+  type    = upper(split("-", each.key)[0])
+  records = [each.value]
+  ttl     = local.dns_tl-org.ttl
+  domain  = desec_domain.dns_tl-org.name
+}
+
+# Buildmaster
+resource "desec_rrset" "tl-org_buildmaster" {
+  subname = "buildmaster"
+  type    = "CNAME"
+  records = ["tahoe-lafs.org."]
+  ttl     = local.dns_tl-org.ttl
+  domain  = desec_domain.dns_tl-org.name
+}
+
+# Wormwhole
+resource "desec_rrset" "tl-org_wormhole" {
+  subname = "wormhole"
+  type    = "CNAME"
+  records = ["relay.magic-wormhole.io."]
+  ttl     = local.dns_tl-org.ttl
+  domain  = desec_domain.dns_tl-org.name
+}
+
+# Testgrid - trac#4160
+resource "desec_rrset" "tl-org_testgrid_ipv4" {
+  subname = "testgrid"
+  type    = "A"
+  records = [hcloud_server.testgrid.ipv4_address]
+  ttl     = local.dns_tl-org.ttl
+  domain  = desec_domain.dns_tl-org.name
+}
+
+resource "desec_rrset" "tl-org_testgrid_ipv6" {
+  subname = "testgrid"
+  type    = "AAAA"
+  records = [hcloud_server.testgrid.ipv6_address]
+  ttl     = local.dns_tl-org.ttl
+  domain  = desec_domain.dns_tl-org.name
+}

--- a/tf/core/providers.tf
+++ b/tf/core/providers.tf
@@ -2,19 +2,19 @@ terraform {
   required_version = "~> 1.4"
 
   required_providers {
+    desec = {
+      source  = "valodim/desec"
+      version = "0.6.1"
+    }
     hcloud = {
       source  = "hetznercloud/hcloud"
       version = "= 1.51.0"
     }
-    hetznerdns = {
-      source  = "germanbrew/hetznerdns"
-      version = "3.4.6"
-    }
   }
 }
 
-provider "hcloud" {
-  token = var.hcloud_token
+provider "desec" {
+  api_token = var.desec_token
 }
 
 provider "hetznerdns" {

--- a/tf/core/variables.tf
+++ b/tf/core/variables.tf
@@ -3,8 +3,8 @@ variable "hcloud_token" {
   type      = string
   sensitive = true
 }
-# The API token to interact with Hetzner DNS
-variable "hdns_token" {
+# The API token to interact with deSec DNS
+variable "desec_token" {
   type      = string
   sensitive = true
 }


### PR DESCRIPTION
Related to #56 

This PR is only meant as a documented example to switch from Hetzner to deSec (and should fail due to the lack of token).

In practice, this migration will have to be done in 5 step with 2 separated PRs:

1. Create a deSec.io account and a valid API token for ToFu
2. Create new domain and records resources in deSec (rather than changing them like in the PR) using this API token as a new sops secret
3. Update the delegation at the registrar level (likely still Gandi) to point to deSec NS with the proper DNSSEC info (+ verification)
4. Destroy de Hetzner DNS resources (rather than changing them like in the PR)
5. Remove the Hetzner DNS API token from the sop secrets and cleanup the related account
