### PR TITLE
Add subdomain to reach webforge FQDN

### DIFF
--- a/nix/known_hosts
+++ b/nix/known_hosts
@@ -1,1 +1,1 @@
-webforge.tahoe-lafs.org,135.181.155.146,2a01:4f9:c011:b882::1 ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIKPX87odbiiSbMyxb2N0curagHWUqSDPBG/P6bQcVzjJ
+webforge.tahoe-lafs.org,webforge.of.tahoe-lafs.org,135.181.155.146,2a01:4f9:c011:b882::1 ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIKPX87odbiiSbMyxb2N0curagHWUqSDPBG/P6bQcVzjJ


### PR DESCRIPTION
Completes #84 

The FQDN was not yet in the knownhost file.

None of this would have been required if we could have had #56 fixed.