### PR TITLE
Update Nix Flake

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -96,11 +96,11 @@
     },
     "nixpkgs-25_05": {
       "locked": {
-        "lastModified": 1761999846,
-        "narHash": "sha256-IYlYnp4O4dzEpL77BD/lj5NnJy2J8qbHkNSFiPBCbqo=",
+        "lastModified": 1764316264,
+        "narHash": "sha256-82L+EJU+40+FIdeG4gmUlOF1jeSwlf2AwMarrpdHF6o=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "3de8f8d73e35724bf9abef41f1bdbedda1e14a31",
+        "rev": "9a7b80b6f82a71ea04270d7ba11b48855681c4b0",
         "type": "github"
       },
       "original": {
@@ -112,11 +112,11 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1761907660,
-        "narHash": "sha256-kJ8lIZsiPOmbkJypG+B5sReDXSD1KGu2VEPNqhRa/ew=",
+        "lastModified": 1764517877,
+        "narHash": "sha256-pp3uT4hHijIC8JUK5MEqeAWmParJrgBVzHLNfJDZxg4=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "2fb006b87f04c4d3bdf08cfdbc7fab9c13d94a15",
+        "rev": "2d293cbfa5a793b4c50d17c05ef9e385b90edf6c",
         "type": "github"
       },
       "original": {
@@ -157,11 +157,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1755110674,
-        "narHash": "sha256-PigqTAGkdBYXVFWsJnqcirrLeFqRFN4PFigLA8FzxeI=",
+        "lastModified": 1763302796,
+        "narHash": "sha256-mEc3SBjRYfMcbNFLxmCc5tRtlu3j+1q7zRz+nRraSFE=",
         "owner": "simple-nixos-mailserver",
         "repo": "nixos-mailserver",
-        "rev": "f5936247dbdb8501221978562ab0b302dd75456c",
+        "rev": "5b38fb599f50e9d78325d1d2706e36303c166047",
         "type": "gitlab"
       },
       "original": {
@@ -178,11 +178,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1760998189,
-        "narHash": "sha256-ee2e1/AeGL5X8oy/HXsZQvZnae6XfEVdstGopKucYLY=",
+        "lastModified": 1764483358,
+        "narHash": "sha256-EyyvCzXoHrbL467YSsQBTWWg4sR96MH1sPpKoSOelB4=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "5a7d18b5c55642df5c432aadb757140edfeb70b3",
+        "rev": "5aca6ff67264321d47856a2ed183729271107c9c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
### Nix Flake Update
```
• Updated input 'nixpkgs-25_05':
    'github:NixOS/nixpkgs/3de8f8d73e35724bf9abef41f1bdbedda1e14a31?narHash=sha256-IYlYnp4O4dzEpL77BD/lj5NnJy2J8qbHkNSFiPBCbqo%3D' (2025-11-01)
  → 'github:NixOS/nixpkgs/9a7b80b6f82a71ea04270d7ba11b48855681c4b0?narHash=sha256-82L%2BEJU%2B40%2BFIdeG4gmUlOF1jeSwlf2AwMarrpdHF6o%3D' (2025-11-28)
• Updated input 'nixpkgs-unstable':
    'github:NixOS/nixpkgs/2fb006b87f04c4d3bdf08cfdbc7fab9c13d94a15?narHash=sha256-kJ8lIZsiPOmbkJypG%2BB5sReDXSD1KGu2VEPNqhRa/ew%3D' (2025-10-31)
  → 'github:NixOS/nixpkgs/2d293cbfa5a793b4c50d17c05ef9e385b90edf6c?narHash=sha256-pp3uT4hHijIC8JUK5MEqeAWmParJrgBVzHLNfJDZxg4%3D' (2025-11-30)
• Updated input 'simple-nixos-mailserver':
    'gitlab:simple-nixos-mailserver/nixos-mailserver/f5936247dbdb8501221978562ab0b302dd75456c?narHash=sha256-PigqTAGkdBYXVFWsJnqcirrLeFqRFN4PFigLA8FzxeI%3D' (2025-08-13)
  → 'gitlab:simple-nixos-mailserver/nixos-mailserver/5b38fb599f50e9d78325d1d2706e36303c166047?narHash=sha256-mEc3SBjRYfMcbNFLxmCc5tRtlu3j%2B1q7zRz%2BnRraSFE%3D' (2025-11-16)
• Updated input 'sops-nix':
    'github:Mic92/sops-nix/5a7d18b5c55642df5c432aadb757140edfeb70b3?narHash=sha256-ee2e1/AeGL5X8oy/HXsZQvZnae6XfEVdstGopKucYLY%3D' (2025-10-20)
  → 'github:Mic92/sops-nix/5aca6ff67264321d47856a2ed183729271107c9c?narHash=sha256-EyyvCzXoHrbL467YSsQBTWWg4sR96MH1sPpKoSOelB4%3D' (2025-11-30)
```
### Nix Shell Diff
```

```
