### PR TITLE
Escape the introducer node name in the tahoe preStart

### DIFF
--- a/testgrid.tahoe-lafs.org/tahoe-service.nix
+++ b/testgrid.tahoe-lafs.org/tahoe-service.nix
@@ -251,8 +251,8 @@ in
             # XXX I thought that a symlink would work here, but it doesn't, so
             # we must do this on every prestart. Fixes welcome.
             # rm $STATE_DIRECTORY/tahoe.cfg
-            # ln -s /etc/tahoe-lafs/introducer-${node}.cfg $STATE_DIRECTORY/tahoe.cfg
-            cp /etc/tahoe-lafs/introducer-"${node}".cfg $STATE_DIRECTORY/tahoe.cfg
+            # ln -s /etc/tahoe-lafs/introducer-${lib.escapeShellArg node}.cfg $STATE_DIRECTORY/tahoe.cfg
+            cp /etc/tahoe-lafs/introducer-${lib.escapeShellArg node}.cfg $STATE_DIRECTORY/tahoe.cfg
           '';
         }
       );


### PR DESCRIPTION
The services.tahoe introducer preStart copies /etc/tahoe-lafs/introducer-"${node}".cfg with the attribute name wrapped only in shell double quotes, and command substitution still runs inside double quotes, so an introducer whose name contains $(...) or backticks gets executed during the copy step of the unit. The sibling nodes branch already routes the same attribute name through lib.escapeShellArg, so this applies the same escaping to the introducer branch and keeps the two paths consistent.